### PR TITLE
Increse Google's Guava version to 32.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>30.0-jre</version>
+			<version>32.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>


### PR DESCRIPTION
Fixes https://github.com/EclipseConTutorial/test-repo-zeta/security/dependabot/2